### PR TITLE
modules

### DIFF
--- a/modules.js
+++ b/modules.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const forks = require('./forks');
+
+// For any external that is used in a DEV-only condition, explicitly
+// specify whether it has side effects during import or not. This lets
+// us know whether we can safely omit them when they are unused.
+const HAS_NO_SIDE_EFFECTS_ON_IMPORT = false;
+// const HAS_SIDE_EFFECTS_ON_IMPORT = true;
+const importSideEffects = Object.freeze({
+  fs: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'fs/promises': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  path: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  stream: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'prop-types/checkPropTypes': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface':
+    HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  scheduler: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  react: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'react-dom/server': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'react/jsx-dev-runtime': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'react-dom': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  url: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  ReactNativeInternalFeatureFlags: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'webpack-sources/lib/helpers/createMappingsSerializer.js':
+    HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'webpack-sources/lib/helpers/readMappings.js': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+});
+
+// Bundles exporting globals that other modules rely on.
+const knownGlobals = Object.freeze({
+  react: 'React',
+  'react-dom': 'ReactDOM',
+  'react-dom/server': 'ReactDOMServer',
+  scheduler: 'Scheduler',
+  'scheduler/unstable_mock': 'SchedulerMock',
+  ReactNativeInternalFeatureFlags: 'ReactNativeInternalFeatureFlags',
+});
+
+// Given ['react'] in bundle externals, returns { 'react': 'React' }.
+function getPeerGlobals(externals, bundleType) {
+  const peerGlobals = {};
+  externals.forEach(name => {
+    peerGlobals[name] = knownGlobals[name];
+  });
+  return peerGlobals;
+}
+
+// Determines node_modules packages that are safe to assume will exist.
+function getDependencies(bundleType, entry) {
+  // Replaces any part of the entry that follow the package name (like
+  // "/server" in "react-dom/server") by the path to the package settings
+  const packageJson = require(entry.replace(/(\/.*)?$/, '/package.json'));
+  // Both deps and peerDeps are assumed as accessible.
+  return Array.from(
+    new Set([
+      ...Object.keys(packageJson.dependencies || {}),
+      ...Object.keys(packageJson.peerDependencies || {}),
+    ])
+  );
+}
+
+// Hijacks some modules for optimization and integration reasons.
+function getForks(bundleType, entry, moduleType, bundle) {
+  const forksForBundle = {};
+  Object.keys(forks).forEach(srcModule => {
+    const dependencies = getDependencies(bundleType, entry);
+    const targetModule = forks[srcModule](
+      bundleType,
+      entry,
+      dependencies,
+      moduleType,
+      bundle
+    );
+    if (targetModule === null) {
+      return;
+    }
+    forksForBundle[srcModule] = targetModule;
+  });
+  return forksForBundle;
+}
+
+function getImportSideEffects() {
+  return importSideEffects;
+}
+
+module.exports = {
+  getImportSideEffects,
+  getPeerGlobals,
+  getDependencies,
+  getForks,
+};


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [x] unit tests
- [x] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
